### PR TITLE
Decreasing Volume Fix

### DIFF
--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -367,10 +367,10 @@ class SoundFrontEnd
         // Ensure x is between 0 and 1
         x = Math.max(0, Math.min(1, x));
 
-				if (x == 0)
-				{
-					return 0;
-				}
+		if (x == 0)
+		{
+			return 0;
+		}
 
         // Convert linear scale to logarithmic
         return Math.exp(Math.log(minValue) * (1 - x));
@@ -380,10 +380,10 @@ class SoundFrontEnd
         // Ensure x is between minValue and 1
         x = Math.max(minValue, Math.min(1, x));
 
-				if (x == minValue)
-				{
-					return 0;
-				}
+		if (x == minValue)
+		{
+			return 0;
+		}
 
         // Convert logarithmic scale to linear
         return 1 - (Math.log(x) / Math.log(minValue));

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -363,20 +363,22 @@ class SoundFrontEnd
 		showSoundTray(Amount > 0);
 	}
 
-	public function linearToLog(x:Float, minValue:Float = 0.001):Float {
+	public function linearToLog(x:Float, minValue:Float = 0.001):Float 
+    {
         // Ensure x is between 0 and 1
         x = Math.max(0, Math.min(1, x));
 
 		if (x == 0)
 		{
-			return 0;
+			return minValue;
 		}
 
         // Convert linear scale to logarithmic
         return Math.exp(Math.log(minValue) * (1 - x));
     }
 
-    public function logToLinear(x:Float, minValue:Float = 0.001):Float {
+    public function logToLinear(x:Float, minValue:Float = 0.001):Float 
+    {
         // Ensure x is between minValue and 1
         x = Math.max(minValue, Math.min(1, x));
 

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -364,8 +364,7 @@ class SoundFrontEnd
 		showSoundTray(Amount > 0);
 	}
 
-	public function linearToLog(x:Float, minValue:Float = 0.001):Float 
-    {
+	public function linearToLog(x:Float, minValue:Float = 0.001):Float {
         // Ensure x is between 0 and 1
         x = Math.max(0, Math.min(1, x));
 
@@ -373,8 +372,7 @@ class SoundFrontEnd
         return Math.exp(Math.log(minValue) * (1 - x));
     }
 
-    public function logToLinear(x:Float, minValue:Float = 0.001):Float 
-    {
+    public function logToLinear(x:Float, minValue:Float = 0.001):Float {
         // Ensure x is between minValue and 1
         x = Math.max(minValue, Math.min(1, x));
 

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -367,6 +367,11 @@ class SoundFrontEnd
         // Ensure x is between 0 and 1
         x = Math.max(0, Math.min(1, x));
 
+				if (x == 0)
+				{
+					return 0;
+				}
+
         // Convert linear scale to logarithmic
         return Math.exp(Math.log(minValue) * (1 - x));
     }
@@ -374,6 +379,11 @@ class SoundFrontEnd
     public function logToLinear(x:Float, minValue:Float = 0.001):Float {
         // Ensure x is between minValue and 1
         x = Math.max(minValue, Math.min(1, x));
+
+				if (x == minValue)
+				{
+					return 0;
+				}
 
         // Convert logarithmic scale to linear
         return 1 - (Math.log(x) / Math.log(minValue));

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -360,6 +360,7 @@ class SoundFrontEnd
 		volume = logToLinear(volume);
 		volume += Amount;
 		volume = linearToLog(volume);
+        volume = (volume == 0.001 ? 0 : volume);
 		showSoundTray(Amount > 0);
 	}
 
@@ -367,11 +368,6 @@ class SoundFrontEnd
     {
         // Ensure x is between 0 and 1
         x = Math.max(0, Math.min(1, x));
-
-		if (x == 0)
-		{
-			return 0;
-		}
 
         // Convert linear scale to logarithmic
         return Math.exp(Math.log(minValue) * (1 - x));

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -370,7 +370,7 @@ class SoundFrontEnd
 
 		if (x == 0)
 		{
-			return minValue;
+			return 0;
 		}
 
         // Convert linear scale to logarithmic
@@ -381,11 +381,6 @@ class SoundFrontEnd
     {
         // Ensure x is between minValue and 1
         x = Math.max(minValue, Math.min(1, x));
-
-		if (x == minValue)
-		{
-			return 0;
-		}
 
         // Convert logarithmic scale to linear
         return 1 - (Math.log(x) / Math.log(minValue));

--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -360,7 +360,8 @@ class SoundFrontEnd
 		volume = logToLinear(volume);
 		volume += Amount;
 		volume = linearToLog(volume);
-        volume = (volume == 0.001 ? 0 : volume);
+		var error:Float = 0.0001; // stupid floating point shit
+		volume = (volume <= (0.001 + error) ? 0 : volume);
 		showSoundTray(Amount > 0);
 	}
 


### PR DESCRIPTION
This fixes a problem mentioned in this [issue](https://github.com/FunkinCrew/Funkin/issues/3394)

We could also use a conditional in `linearToLog` and say that a linear volume of 0 returns 0 even when converting logarithmic volume, but i dont know if that is a good idea, because someone might not expect such behaviour

