### PR TITLE
[BUGFIX] FlxBar graphic destroy fix

### DIFF
--- a/flixel/ui/FlxBar.hx
+++ b/flixel/ui/FlxBar.hx
@@ -993,10 +993,10 @@ class FlxBar extends FlxSprite
 	{
 		if (FlxG.renderTile)
 		{
-			if (value != null)
+			if (value != null && value.parent != null)
 				value.parent.incrementUseCount();
 				
-			if (frontFrames != null)
+			if (frontFrames != null && frontFrames.parent != null)
 				frontFrames.parent.decrementUseCount();
 
 			frontFrames = value;


### PR DESCRIPTION
Fixes a bug where destroying a flxbar with a destroyed associated graphic would crash the game