### PR TITLE
Optimization to avoid redraws when setting text to the same value.

### DIFF
--- a/flixel/text/FlxText.hx
+++ b/flixel/text/FlxText.hx
@@ -31,10 +31,10 @@ import openfl.geom.Rectangle;
 /**
  * Extends FlxSprite to support rendering text. Can tint, fade, rotate and scale just like a sprite. Doesn't really animate
  * though. Also does nice pixel-perfect centering on pixel fonts as long as they are only one-liners.
- * 
+ *
  * ## Autosizing
- * 
- * By default `FlxText` is autosized to fit it's text. 
+ *
+ * By default `FlxText` is autosized to fit it's text.
  * To set a fixed size, use the `fieldWidth`, `fieldHeight` and `autoSize` fields.
  */
 class FlxText extends FlxSprite
@@ -135,7 +135,7 @@ class FlxText extends FlxSprite
 	/**
 	 * The width of the `TextField` object used for bitmap generation for this `FlxText` object.
 	 * Use it when you want to change the visible width of text. Enables `autoSize` if `<= 0`.
-	 * 
+	 *
 	 * **NOTE:** auto width always implies auto height
 	 */
 	public var fieldWidth(get, set):Float;
@@ -143,37 +143,37 @@ class FlxText extends FlxSprite
 	/**
 	 * The height of `TextField` object used for bitmap generation for this `FlxText` object.
 	 * Use it when you want to change the visible height of the text. Enables "auto height" if `<= 0`.
-	 * 
+	 *
 	 * **NOTE:** Fixed height has no effect if `autoSize = true`.
 	 * @since 5.4.0
 	 */
 	public var fieldHeight(get, set):Float;
 
 	/**
-	 * Whether the `fieldWidth` and `fieldHeight` should be determined automatically. 
+	 * Whether the `fieldWidth` and `fieldHeight` should be determined automatically.
 	 * Requires `wordWrap` to be `false`.
 	 */
 	public var autoSize(get, set):Bool;
 
 	var _autoHeight:Bool = true;
-	
+
 	/**
 	 * Internal handler for deprecated `shadowOffset` field
 	 */
 	var _shadowOffset:FlxPoint = FlxPoint.get(1, 1);
-	
+
 	/**
 	 * Offset that is applied to the shadow border style, if active.
 	 * `x` and `y` are multiplied by `borderSize`. Default is `(1, 1)`, or lower-right corner.
 	 */
 	@:deprecated("shadowOffset is deprecated, use setBorderStyle(SHADOW_XY(offsetX, offsetY)), instead") // 5.9.0
 	public var shadowOffset(get, never):FlxPoint;
-	
+
 	/**
 	 * Used to offset the graphic to account for the border
 	 */
 	var _graphicOffset:FlxPoint = FlxPoint.get(0, 0);
-	
+
 	var _defaultFormat:TextFormat;
 	var _formatAdjusted:TextFormat;
 	var _formatRanges:Array<FlxTextFormatRange> = [];
@@ -567,10 +567,17 @@ class FlxText extends FlxSprite
 	function set_fieldWidth(value:Float):Float
 	{
 		if (textField == null)
+		{
 			return value;
+		}
 
 		if (value <= 0)
 		{
+			if (this.fieldWidth <= 0)
+			{
+				return this.fieldWidth;
+			}
+
 			wordWrap = false;
 			autoSize = true;
 			// auto width always implies auto height
@@ -578,6 +585,11 @@ class FlxText extends FlxSprite
 		}
 		else
 		{
+			if (this.fieldWidth == value)
+			{
+				return this.fieldWidth;
+			}
+
 			autoSize = false;
 			wordWrap = true;
 			textField.width = value;
@@ -600,23 +612,41 @@ class FlxText extends FlxSprite
 	function set_fieldHeight(value:Float):Float
 	{
 		if (textField == null)
+		{
 			return value;
+		}
 
 		if (value <= 0)
 		{
+			if (this.fieldHeight <= 0)
+			{
+				return this.fieldHeight;
+			}
+
 			_autoHeight = true;
 		}
 		else
 		{
+			if (this.fieldHeight == value)
+			{
+				return this.fieldHeight;
+			}
+
 			_autoHeight = false;
 			textField.height = value;
 		}
+
 		_regen = true;
 		return value;
 	}
 
 	function set_autoSize(value:Bool):Bool
 	{
+		if (this.autoSize == value)
+		{
+			return this.autoSize;
+		}
+
 		if (textField != null)
 		{
 			textField.autoSize = value ? TextFieldAutoSize.LEFT : TextFieldAutoSize.NONE;
@@ -633,6 +663,11 @@ class FlxText extends FlxSprite
 
 	function set_text(Text:String):String
 	{
+		if (text == Text)
+		{
+			return text;
+		}
+
 		text = Text;
 		if (textField != null)
 		{
@@ -650,6 +685,11 @@ class FlxText extends FlxSprite
 
 	function set_size(Size:Int):Int
 	{
+		if (_defaultFormat.size == Size)
+		{
+			return _defaultFormat.size;
+		}
+
 		_defaultFormat.size = Size;
 		updateDefaultFormat();
 		return Size;
@@ -662,11 +702,16 @@ class FlxText extends FlxSprite
 
 	function set_letterSpacing(LetterSpacing:Float):Float
 	{
+		if (_defaultFormat.letterSpacing == LetterSpacing)
+		{
+			return _defaultFormat.letterSpacing;
+		}
+
 		_defaultFormat.letterSpacing = LetterSpacing;
 		updateDefaultFormat();
 		return LetterSpacing;
 	}
-	
+
 	override function setColorTransform(redMultiplier = 1.0, greenMultiplier = 1.0, blueMultiplier = 1.0, alphaMultiplier = 1.0, redOffset = 0.0, greenOffset = 0.0, blueOffset = 0.0, alphaOffset = 0.0)
 	{
 		super.setColorTransform(1, 1, 1, 1, redOffset, greenOffset, blueOffset, alphaOffset);
@@ -680,6 +725,7 @@ class FlxText extends FlxSprite
 		{
 			return value;
 		}
+
 		_defaultFormat.color = value.rgb;
 		color = value;
 		updateDefaultFormat();
@@ -693,6 +739,11 @@ class FlxText extends FlxSprite
 
 	function set_font(Font:String):String
 	{
+		if (_font == Font)
+		{
+			return _font;
+		}
+
 		textField.embedFonts = true;
 
 		if (Font != null)
@@ -766,7 +817,7 @@ class FlxText extends FlxSprite
 	{
 		return _defaultFormat.underline;
 	}
-	
+
 	function set_underline(value:Bool):Bool
 	{
 		if (_defaultFormat.underline != value)
@@ -856,7 +907,7 @@ class FlxText extends FlxSprite
 		regenGraphic();
 		return super.get_height();
 	}
-	
+
 	inline function get_shadowOffset()
 	{
 		return _shadowOffset;
@@ -873,13 +924,13 @@ class FlxText extends FlxSprite
 	{
 		if (textField == null || !_regen)
 			return;
-		
+
 		final oldWidth:Int = graphic != null ? graphic.width : 0;
 		final oldHeight:Int = graphic != null ? graphic.height : VERTICAL_GUTTER;
-		
+
 		final newWidthFloat:Float = textField.width;
 		final newHeightFloat:Float = _autoHeight ? textField.textHeight + VERTICAL_GUTTER : textField.height;
-		
+
 		var borderWidth:Float = 0;
 		var borderHeight:Float = 0;
 		switch(borderStyle)
@@ -887,25 +938,25 @@ class FlxText extends FlxSprite
 			case SHADOW if (_shadowOffset.x != 1 || _shadowOffset.y != 1):
 				borderWidth += Math.abs(_shadowOffset.x);
 				borderHeight += Math.abs(_shadowOffset.y);
-			
+
 			case SHADOW: // With the default shadowOffset value
 				borderWidth += Math.abs(borderSize);
 				borderHeight += Math.abs(borderSize);
-			
+
 			case SHADOW_XY(offsetX, offsetY):
 				borderWidth += Math.abs(offsetX);
 				borderHeight += Math.abs(offsetY);
-			
+
 			case OUTLINE_FAST | OUTLINE:
 				borderWidth += Math.abs(borderSize) * 2;
 				borderHeight += Math.abs(borderSize) * 2;
-			
+
 			case NONE:
 		}
-		
+
 		final newWidth:Int = Math.ceil(newWidthFloat + borderWidth);
 		final newHeight:Int = Math.ceil(newHeightFloat + borderHeight);
-		
+
 		// prevent text height from shrinking on flash if text == ""
 		if (textField.textHeight != 0 && (oldWidth != newWidth || oldHeight != newHeight))
 		{
@@ -914,11 +965,11 @@ class FlxText extends FlxSprite
 			makeGraphic(newWidth, newHeight, FlxColor.TRANSPARENT, false, key);
 			width = Math.ceil(newWidthFloat);
 			height = Math.ceil(newHeightFloat);
-			
+
 			#if FLX_TRACK_GRAPHICS
 			graphic.trackingInfo = 'text($ID, $text)';
 			#end
-			
+
 			if (_hasBorderAlpha)
 				_borderPixels = graphic.bitmap.clone();
 
@@ -1024,43 +1075,43 @@ class FlxText extends FlxSprite
 		regenGraphic();
 		super.draw();
 	}
-	
+
 	override function drawSimple(camera:FlxCamera):Void
 	{
 		// same as super but checks _graphicOffset
 		getScreenPosition(_point, camera).subtract(offset).subtract(_graphicOffset);
 		if (isPixelPerfectRender(camera))
 			_point.floor();
-		
+
 		_point.copyTo(_flashPoint);
 		camera.copyPixels(_frame, framePixels, _flashRect, _flashPoint, colorTransform, blend, antialiasing);
 	}
-	
+
 	override function drawComplex(camera:FlxCamera):Void
 	{
 		_frame.prepareMatrix(_matrix, ANGLE_0, checkFlipX(), checkFlipY());
 		_matrix.translate(-origin.x, -origin.y);
 		_matrix.scale(scale.x, scale.y);
-		
+
 		if (bakedRotationAngle <= 0)
 		{
 			updateTrig();
-			
+
 			if (angle != 0)
 				_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 		}
-		
+
 		// same as super but checks _graphicOffset
 		getScreenPosition(_point, camera).subtract(offset).subtract(_graphicOffset);
 		_point.add(origin.x, origin.y);
 		_matrix.translate(_point.x, _point.y);
-		
+
 		if (isPixelPerfectRender(camera))
 		{
 			_matrix.tx = Math.floor(_matrix.tx);
 			_matrix.ty = Math.floor(_matrix.ty);
 		}
-		
+
 		camera.drawPixels(_frame, framePixels, _matrix, colorTransform, blend, antialiasing, shader);
 	}
 
@@ -1080,7 +1131,7 @@ class FlxText extends FlxSprite
 		regenGraphic();
 		super.calcFrame(RunOnCpp);
 	}
-	
+
 	function applyBorderStyle():Void
 	{
 		// offset entire image to fit the border
@@ -1089,45 +1140,45 @@ class FlxText extends FlxSprite
 			case SHADOW if (_shadowOffset.x != 1 || _shadowOffset.y != 1):
 				_graphicOffset.x = _shadowOffset.x > 0 ? _shadowOffset.x : 0;
 				_graphicOffset.y = _shadowOffset.y > 0 ? _shadowOffset.y : 0;
-			
+
 			case SHADOW: // With the default shadowOffset value
 				if (borderSize < 0)
 					_graphicOffset.set(-borderSize, -borderSize);
-			
+
 			case SHADOW_XY(offsetX, offsetY):
 				_graphicOffset.x = offsetX < 0 ? -offsetX : 0;
 				_graphicOffset.y = offsetY < 0 ? -offsetY : 0;
-			
+
 			case OUTLINE_FAST | OUTLINE if (borderSize < 0):
 				_graphicOffset.set(-borderSize, -borderSize);
-			
+
 			case NONE | OUTLINE_FAST | OUTLINE:
 				_graphicOffset.set(0, 0);
 		}
 		_matrix.translate(_graphicOffset.x, _graphicOffset.y);
-		
+
 		switch (borderStyle)
 		{
 			case SHADOW if (_shadowOffset.x != 1 || _shadowOffset.y != 1):
 				// Render a shadow beneath the text using the shadowOffset property
 				applyFormats(_formatAdjusted, true);
-				
+
 				var iterations = borderQuality < 1 ? 1 : Std.int(Math.abs(borderSize) * borderQuality);
 				final delta = borderSize / iterations;
 				for (i in 0...iterations)
 				{
 					copyTextWithOffset(delta, delta);
 				}
-				
+
 				_matrix.translate(-_shadowOffset.x * borderSize, -_shadowOffset.y * borderSize);
-			
+
 			case SHADOW: // With the default shadowOffset value
 				// Render a shadow beneath the text
 				applyFormats(_formatAdjusted, true);
-				
+
 				final originX = _matrix.tx;
 				final originY = _matrix.ty;
-				
+
 				final iterations = borderQuality < 1 ? 1 : Std.int(Math.abs(borderSize) * borderQuality);
 				var i = iterations + 1;
 				while (i-- > 1)
@@ -1137,14 +1188,14 @@ class FlxText extends FlxSprite
 					_matrix.tx = originX;
 					_matrix.ty = originY;
 				}
-			
+
 			case SHADOW_XY(shadowX, shadowY):
 				// Render a shadow beneath the text with the specified offset
 				applyFormats(_formatAdjusted, true);
-				
+
 				final originX = _matrix.tx;
 				final originY = _matrix.ty;
-				
+
 				// Size is max of both, so (4, 4) has 4 iterations, just like SHADOW
 				final size = Math.max(shadowX, shadowY);
 				final iterations = borderQuality < 1 ? 1 : Std.int(size * borderQuality);
@@ -1156,12 +1207,12 @@ class FlxText extends FlxSprite
 					_matrix.tx = originX;
 					_matrix.ty = originY;
 				}
-			
+
 			case OUTLINE:
 				// Render an outline around the text
 				// (do 8 offset draw calls)
 				applyFormats(_formatAdjusted, true);
-				
+
 				final iterations = FlxMath.maxInt(1, Std.int(borderSize * borderQuality));
 				var i = iterations + 1;
 				while (i-- > 1)
@@ -1175,16 +1226,16 @@ class FlxText extends FlxSprite
 					copyTextWithOffset(-curDelta, 0); // lower-middle
 					copyTextWithOffset(-curDelta, 0); // lower-left
 					copyTextWithOffset(0, -curDelta); // lower-left
-					
+
 					_matrix.translate(curDelta, 0); // return to center
 				}
-			
+
 			case OUTLINE_FAST:
 				// Render an outline around the text
 				// (do 4 diagonal offset draw calls)
 				// (this method might not work with certain narrow fonts)
 				applyFormats(_formatAdjusted, true);
-				
+
 				final iterations = FlxMath.maxInt(1, Std.int(borderSize * borderQuality));
 				var i = iterations + 1;
 				while (i-- > 1)
@@ -1194,10 +1245,10 @@ class FlxText extends FlxSprite
 					copyTextWithOffset(curDelta * 2, 0); // upper-right
 					copyTextWithOffset(0, curDelta * 2); // lower-right
 					copyTextWithOffset(-curDelta * 2, 0); // lower-left
-					
+
 					_matrix.translate(curDelta, -curDelta); // return to center
 				}
-			
+
 			case NONE:
 		}
 	}
@@ -1291,6 +1342,11 @@ class FlxText extends FlxSprite
 
 	override function set_antialiasing(value:Bool):Bool
 	{
+		if (this.antialiasing == value)
+		{
+			return this.antialiasing;
+		}
+
 		if (value)
 		{
 			textField.antiAliasType = NORMAL;
@@ -1371,23 +1427,23 @@ class FlxTextFormatMarkerPair
 enum FlxTextBorderStyle
 {
 	NONE;
-	
+
 	/**
 	 * A simple shadow to the lower-right
 	 */
 	SHADOW;
-	
+
 	/**
 	 * A shadow that allows custom placement
 	 * **Note:** Ignores borderSize
 	 */
 	SHADOW_XY(offsetX:Float, offsetY:Float);
-	
+
 	/**
 	 * Outline on all 8 sides
 	 */
 	OUTLINE;
-	
+
 	/**
 	 * Outline, optimized using only 4 draw calls
 	 * **Note:** Might not work for narrow and/or 1-pixel fonts


### PR DESCRIPTION
By checking if `this.text == value` you can prevent unnecessary redraws and save a bit of performance. Good for the chart editor where sometimes scrolling will constantly modify text.