### PR TITLE
Implement `SDL3`

### DIFF
--- a/flixel/FlxG.hx
+++ b/flixel/FlxG.hx
@@ -70,8 +70,9 @@ class FlxG
 	public static var autoPause:Bool = true;
 
 	/**
-	 * WARNING: Changing this can lead to issues with physics and the recording system. Setting this to
-	 * `false` might lead to smoother animations (even at lower fps) at the cost of physics accuracy.
+	 * WARNING: Changing this can lead to issues with physics and the recording system. Setting this to `false` might lead to smoother animations (even at lower fps) at the cost of physics accuracy.
+	 * 
+	 * UPDATE: The new mainloop inside lime should no longer require this and so rn it does nothing.
 	 */
 	public static var fixedTimestep:Bool = true;
 
@@ -656,7 +657,6 @@ class FlxG
 		sound.destroy(true);
 		#end
 		autoPause = true;
-		fixedTimestep = true;
 		timeScale = 1.0;
 		animationTimeScale = 1.0;
 		elapsed = 0;
@@ -702,12 +702,6 @@ class FlxG
 
 		updateFramerate = value;
 
-		game._stepMS = Math.abs(1000 / value);
-		game._stepSeconds = game._stepMS / 1000;
-
-		if (game._maxAccumulation < game._stepMS)
-			game._maxAccumulation = game._stepMS;
-
 		return value;
 	}
 
@@ -716,15 +710,10 @@ class FlxG
 		if (value > updateFramerate)
 			log.warn("FlxG.drawFramerate: the update framerate shouldn't be smaller than the draw framerate," + " since it can stop your game from updating.");
 
-		drawFramerate = Std.int(Math.abs(value));
+		drawFramerate = value;
 
 		if (game.stage != null)
 			game.stage.frameRate = drawFramerate;
-
-		game._maxAccumulation = 2000 / drawFramerate - 1;
-
-		if (game._maxAccumulation < game._stepMS)
-			game._maxAccumulation = game._stepMS;
 
 		return value;
 	}

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -74,7 +74,7 @@ class FlxGame extends Sprite
 	/**
 	 * Time in milliseconds that has passed (amount of "ticks" passed) since the game has started.
 	 */
-	public var ticks(default, null):Int = 0;
+	public var ticks(default, null):Float = 0;
 
 	/**
 	 * Enables or disables the filters set via `setFilters()`.
@@ -100,13 +100,13 @@ class FlxGame extends Sprite
 	/**
 	 * Total number of milliseconds elapsed since game start.
 	 */
-	var _total:Int = 0;
+	var _total:Float = 0;
 
 	/**
 	 * Time stamp of game startup. Needed on JS where `Lib.getTimer()`
 	 * returns time stamp of current date, not the time passed since app start.
 	 */
-	var _startTime:Int = 0;
+	var _startTime:Float = 0;
 
 	/**
 	 * Total number of milliseconds elapsed since last update loop.
@@ -842,7 +842,7 @@ class FlxGame extends Sprite
 		return getTimer() - _startTime;
 	}
 
-	dynamic function getTimer():Int
+	dynamic function getTimer():Float
 	{
 		// expensive, only call if necessary
 		return Lib.getTimer();

--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -97,43 +97,18 @@ class FlxGame extends Sprite
 	 */
 	var _state:FlxState;
 
+	#if flash
 	/**
 	 * Total number of milliseconds elapsed since game start.
 	 */
 	var _total:Float = 0;
+	#end
 
 	/**
 	 * Time stamp of game startup. Needed on JS where `Lib.getTimer()`
 	 * returns time stamp of current date, not the time passed since app start.
 	 */
 	var _startTime:Float = 0;
-
-	/**
-	 * Total number of milliseconds elapsed since last update loop.
-	 * Counts down as we step through the game loop.
-	 */
-	var _accumulator:Float;
-
-	/**
-	 * Milliseconds of time since last step.
-	 */
-	var _elapsedMS:Float;
-
-	/**
-	 * Milliseconds of time per step of the game loop. e.g. 60 fps = 16ms.
-	 */
-	var _stepMS:Float;
-
-	/**
-	 * Optimization so we don't have to divide step by 1000 to get its value in seconds every frame.
-	 */
-	var _stepSeconds:Float;
-
-	/**
-	 * Max allowable accumulation (see `_accumulator`).
-	 * Should always (and automatically) be set to roughly 2x the stage framerate.
-	 */
-	var _maxAccumulation:Float;
 
 	/**
 	 * Whether the game lost focus.
@@ -261,7 +236,6 @@ class FlxGame extends Sprite
 
 		FlxG.updateFramerate = updateFramerate;
 		FlxG.drawFramerate = drawFramerate;
-		_accumulator = _stepMS;
 		_skipSplash = skipSplash;
 
 		#if FLX_RECORD
@@ -293,7 +267,9 @@ class FlxGame extends Sprite
 		removeEventListener(Event.ADDED_TO_STAGE, create);
 
 		_startTime = getTimer();
+		#if flash
 		_total = getTicks();
+		#end
 
 		#if desktop
 		FlxG.fullscreen = _startFullscreen;
@@ -342,8 +318,15 @@ class FlxGame extends Sprite
 		if (FlxG.updateFramerate < FlxG.drawFramerate)
 			FlxG.log.warn("FlxG.updateFramerate: The update framerate shouldn't be smaller" + " than the draw framerate, since it can slow down your game.");
 
+		#if flash
 		// Finally, set up an event for the actual game loop stuff.
-		stage.addEventListener(Event.ENTER_FRAME, onEnterFrame);
+		stage.addEventListener(Event.ENTER_FRAME, function(e)
+		{
+			ticks = getTicks();
+			__enterFrame(ticks - _total);
+			_total = ticks;
+		});
+		#end
 
 		// We need to listen for resize event which means new context
 		// it means that we need to recreate BitmapDatas of dumped tilesheets
@@ -456,15 +439,16 @@ class FlxGame extends Sprite
 	/**
 	 * Handles the `onEnterFrame` call and figures out how many updates and draw calls to do.
 	 */
-	function onEnterFrame(_):Void
+	@SuppressWarnings("checkstyle:MethodName")
+	private #if !flash override #end function __enterFrame(deltaTime:Float):Void
 	{
+		#if !flash
 		ticks = getTicks();
-		_elapsedMS = ticks - _total;
-		_total = ticks;
+		#end
 
 		#if FLX_SOUND_TRAY
 		if (soundTray != null && soundTray.active)
-			soundTray.update(_elapsedMS);
+			soundTray.update(deltaTime);
 		#end
 
 		if (!_lostFocus || !FlxG.autoPause)
@@ -491,21 +475,7 @@ class FlxGame extends Sprite
 				}
 			}
 
-			if (FlxG.fixedTimestep)
-			{
-				_accumulator += _elapsedMS;
-				_accumulator = (_accumulator > _maxAccumulation) ? _maxAccumulation : _accumulator;
-
-				while (_accumulator >= _stepMS)
-				{
-					step();
-					_accumulator -= _stepMS;
-				}
-			}
-			else
-			{
-				step();
-			}
+			step(deltaTime);
 
 			#if FLX_DEBUG
 			FlxBasic.visibleCount = 0;
@@ -518,6 +488,9 @@ class FlxGame extends Sprite
 			debugger.update();
 			#end
 		}
+		#if !flash
+		super.__enterFrame(deltaTime);
+		#end
 	}
 
 	/**
@@ -609,7 +582,7 @@ class FlxGame extends Sprite
 	 * the appropriate number of times each frame.
 	 * This block handles state changes, replays, all that good stuff.
 	 */
-	function step():Void
+	function step(deltaTime:Float):Void
 	{
 		// Handle game reset request
 		if (_resetGame)
@@ -625,7 +598,7 @@ class FlxGame extends Sprite
 		FlxBasic.activeCount = 0;
 		#end
 
-		update();
+		update(deltaTime);
 
 		#if FLX_DEBUG
 		debugger.stats.activeObjects(FlxBasic.activeCount);
@@ -666,7 +639,7 @@ class FlxGame extends Sprite
 	 * This function is called by `step()` and updates the actual game state.
 	 * May be called multiple times per "frame" or draw call.
 	 */
-	function update():Void
+	function update(deltaTime:Float):Void
 	{
 		if (!_state.active || !_state.exists)
 			return;
@@ -679,9 +652,9 @@ class FlxGame extends Sprite
 			ticks = getTicks();
 		#end
 
-		updateElapsed();
+		updateElapsed(deltaTime);
 
-		updateInput();
+		updateInput(deltaTime);
 		
 		FlxG.signals.preUpdate.dispatch();
 
@@ -712,23 +685,17 @@ class FlxGame extends Sprite
 		filters = filtersEnabled ? _filters : null;
 	}
 
-	function updateElapsed():Void
+	function updateElapsed(deltaTime:Float):Void
 	{
-		if (FlxG.fixedTimestep)
-		{
-			FlxG.elapsed = FlxG.timeScale * _stepSeconds; // fixed timestep
-		}
-		else
-		{
-			FlxG.elapsed = FlxG.timeScale * (_elapsedMS / 1000); // variable timestep
+		FlxG.elapsed = FlxG.timeScale * (deltaTime / 1000.0); // variable timestep
 
-			var max = FlxG.maxElapsed * FlxG.timeScale;
-			if (FlxG.elapsed > max)
-				FlxG.elapsed = max;
-		}
+		var max = FlxG.maxElapsed * FlxG.timeScale;
+
+		if (FlxG.elapsed > max)
+			FlxG.elapsed = max;
 	}
 
-	function updateInput():Void
+	function updateInput(deltaTime:Float):Void
 	{
 		#if FLX_RECORD
 		if (replaying)
@@ -737,7 +704,7 @@ class FlxGame extends Sprite
 
 			if (FlxG.vcr.timeout > 0)
 			{
-				FlxG.vcr.timeout -= _stepMS;
+				FlxG.vcr.timeout -= deltaTime;
 
 				if (FlxG.vcr.timeout <= 0)
 				{
@@ -765,7 +732,7 @@ class FlxGame extends Sprite
 			}
 
 			#if FLX_DEBUG
-			debugger.vcr.updateRuntime(_stepMS);
+			debugger.vcr.updateRuntime(deltaTime);
 			#end
 		}
 		else
@@ -782,7 +749,7 @@ class FlxGame extends Sprite
 			_replay.recordFrame();
 
 			#if FLX_DEBUG
-			debugger.vcr.updateRuntime(_stepMS);
+			debugger.vcr.updateRuntime(deltaTime);
 			#end
 		}
 		#end

--- a/flixel/input/FlxSwipe.hx
+++ b/flixel/input/FlxSwipe.hx
@@ -24,10 +24,10 @@ class FlxSwipe implements IFlxDestroyable
 	public var radians(get, never):Float;
 	public var duration(get, never):Float;
 
-	var _startTimeInTicks:Int;
-	var _endTimeInTicks:Int;
+	var _startTimeInTicks:Float;
+	var _endTimeInTicks:Float;
 
-	function new(ID:Int, StartPosition:FlxPoint, EndPosition:FlxPoint, StartTimeInTicks:Int)
+	function new(ID:Int, StartPosition:FlxPoint, EndPosition:FlxPoint, StartTimeInTicks:Float)
 	{
 		this.ID = ID;
 		startPosition = StartPosition;

--- a/flixel/input/actions/FlxAction.hx
+++ b/flixel/input/actions/FlxAction.hx
@@ -341,7 +341,7 @@ class FlxAction implements IFlxDestroyable
 	var _x:Null<Float> = null;
 	var _y:Null<Float> = null;
 
-	var _timestamp:Int = 0;
+	var _timestamp:Float = 0;
 	@:deprecated("_checked is deprecated, use triggered, instead")
 	var _checked:Bool = false;
 

--- a/flixel/input/android/FlxAndroidKey.hx
+++ b/flixel/input/android/FlxAndroidKey.hx
@@ -12,8 +12,8 @@ enum abstract FlxAndroidKey(Int) from Int to Int
 	public static var toStringMap(default, null):Map<FlxAndroidKey, String> = FlxMacroUtil.buildMap("flixel.input.android.FlxAndroidKey", true);
 	var ANY = -2;
 	var NONE = -1;
-	var MENU = 0x4000010C;
-	var BACK = 0x4000010E;
+	var MENU = 0x40000118;
+	var BACK = 0x4000011A;
 
 	@:from
 	public static inline function fromString(s:String)

--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -156,12 +156,12 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 * Time in ticks of last left mouse button press.
 	 * @since 4.3.0
 	 */
-	public var justPressedTimeInTicks(get, never):Int;
+	public var justPressedTimeInTicks(get, never):Float;
 
 	/**
 	 * Time in ticks that had passed since of last press
 	 */
-	public var ticksDeltaSincePress(get, never):Int;
+	public var ticksDeltaSincePress(get, never):Float;
 
 	/**
 	 * The speed of this mouse, always updates.
@@ -206,7 +206,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 * Time in ticks of last right mouse button press.
 	 * @since 4.3.0
 	 */
-	public var justPressedTimeInTicksRight(get, never):Int;
+	public var justPressedTimeInTicksRight(get, never):Float;
 
 	/**
 	 * Check to see if the middle mouse button is currently pressed.
@@ -233,7 +233,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 * Time in ticks of last middle mouse button press.
 	 * @since 4.3.0
 	 */
-	public var justPressedTimeInTicksMiddle(get, never):Int;
+	public var justPressedTimeInTicksMiddle(get, never):Float;
 	#end
 
 	/**
@@ -797,11 +797,11 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		return _leftButton.justReleased;
 
 	@:noCompletion
-	function get_justPressedTimeInTicks():Int
+	function get_justPressedTimeInTicks():Float
 		return _leftButton.justPressedTimeInTicks;
 
 	@:noCompletion
-	function get_ticksDeltaSincePress():Int
+	function get_ticksDeltaSincePress():Float
 		return FlxG.game.ticks - justPressedTimeInTicks;
 
 	#if FLX_MOUSE_ADVANCED
@@ -822,7 +822,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		return _rightButton.justReleased;
 
 	@:noCompletion
-	inline function get_justPressedTimeInTicksRight():Int
+	inline function get_justPressedTimeInTicksRight():Float
 		return _rightButton.justPressedTimeInTicks;
 
 	@:noCompletion
@@ -842,7 +842,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		return _middleButton.justReleased;
 
 	@:noCompletion
-	inline function get_justPressedTimeInTicksMiddle():Int
+	inline function get_justPressedTimeInTicksMiddle():Float
 		return _middleButton.justPressedTimeInTicks;
 	#end
 

--- a/flixel/input/mouse/FlxMouseButton.hx
+++ b/flixel/input/mouse/FlxMouseButton.hx
@@ -23,7 +23,7 @@ class FlxMouseButton extends FlxInput<Int> implements IFlxDestroyable
 	}
 
 	public var justPressedPosition(default, null) = FlxPoint.get();
-	public var justPressedTimeInTicks(default, null):Int = -1;
+	public var justPressedTimeInTicks(default, null):Float = -1;
 
 	/**
 	 * Updates the last and current state of this mouse button.

--- a/flixel/input/mouse/FlxMouseEventManager.hx
+++ b/flixel/input/mouse/FlxMouseEventManager.hx
@@ -30,7 +30,7 @@ class FlxMouseEventManager extends FlxBasic
 	var _downList:Array<FlxMouseEvent<FlxObject>> = [];
 	var _clickList:Array<FlxMouseEvent<FlxObject>> = [];
 
-	var mouseClickedTime:Int = -1;
+	var mouseClickedTime:Float = -1;
 
 	@:noCompletion
 	var _point:FlxPoint = FlxPoint.get();

--- a/flixel/input/touch/FlxTouch.hx
+++ b/flixel/input/touch/FlxTouch.hx
@@ -77,7 +77,7 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 	/**
 	 * Time in ticks of last press.
 	 */
-	public var justPressedTimeInTicks(default, null):Int = -1;
+	public var justPressedTimeInTicks(default, null):Float = -1;
 
 	/**
 	 * Distance in pixels this touch has moved since the last frame in the X direction.
@@ -107,7 +107,7 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 	/**
 	 * Time in ticks that had passed since of last press
 	 */
-	public var ticksDeltaSincePress(get, default):Int;
+	public var ticksDeltaSincePress(get, default):Float;
 
 	/**
 	 * The speed of this touch, always updates.
@@ -326,7 +326,7 @@ class FlxTouch extends FlxPointer implements IFlxDestroyable implements IFlxInpu
 		return viewY - _startY;
 
 	@:noCompletion
-	inline function get_ticksDeltaSincePress():Int
+	inline function get_ticksDeltaSincePress():Float
 		return FlxG.game.ticks - justPressedTimeInTicks;
 }
 #else

--- a/flixel/system/FlxSplash.hx
+++ b/flixel/system/FlxSplash.hx
@@ -30,7 +30,6 @@ class FlxSplash extends FlxState
 	var _functions:Array<Void->Void>;
 	var _curPart:Int = 0;
 	var _cachedBgColor:FlxColor;
-	var _cachedTimestep:Bool;
 	var _cachedAutoPause:Bool;
 	
 	var nextState:NextState;
@@ -45,10 +44,6 @@ class FlxSplash extends FlxState
 	{
 		_cachedBgColor = FlxG.cameras.bgColor;
 		FlxG.cameras.bgColor = FlxColor.BLACK;
-
-		// This is required for sound and animation to synch up properly
-		_cachedTimestep = FlxG.fixedTimestep;
-		FlxG.fixedTimestep = false;
 
 		_cachedAutoPause = FlxG.autoPause;
 		FlxG.autoPause = false;
@@ -204,7 +199,6 @@ class FlxSplash extends FlxState
 	override function startOutro(onOutroComplete:() -> Void)
 	{
 		FlxG.cameras.bgColor = _cachedBgColor;
-		FlxG.fixedTimestep = _cachedTimestep;
 		FlxG.autoPause = _cachedAutoPause;
 		#if FLX_KEYBOARD
 		FlxG.keys.enabled = true;

--- a/flixel/system/debug/stats/Stats.hx
+++ b/flixel/system/debug/stats/Stats.hx
@@ -43,7 +43,7 @@ class Stats extends Window
 	var _leftTextField:TextField;
 	var _rightTextField:TextField;
 
-	var _itvTime:Int = 0;
+	var _itvTime:Float = 0;
 	var _frameCount:Int;
 	var _currentTime:Int;
 

--- a/flixel/system/debug/stats/Stats.hx
+++ b/flixel/system/debug/stats/Stats.hx
@@ -45,7 +45,7 @@ class Stats extends Window
 
 	var _itvTime:Float = 0;
 	var _frameCount:Int;
-	var _currentTime:Int;
+	var _currentTime:Float;
 
 	var fpsGraph:StatsGraph;
 	var memoryGraph:StatsGraph;
@@ -55,17 +55,17 @@ class Stats extends Window
 	var flashPlayerFramerate:Float = 0;
 	var visibleCount:Int = 0;
 	var activeCount:Int = 0;
-	var updateTime:Int = 0;
-	var drawTime:Int = 0;
+	var updateTime:Float = 0;
+	var drawTime:Float = 0;
 	var drawCallsCount:Int = 0;
 
-	var _lastTime:Int = 0;
-	var _updateTimer:Int = 0;
+	var _lastTime:Float = 0;
+	var _updateTimer:Float = 0;
 
-	var _update:Array<Int> = [];
+	var _update:Array<Float> = [];
 	var _updateMarker:Int = 0;
 
-	var _draw:Array<Int> = [];
+	var _draw:Array<Float> = [];
 	var _drawMarker:Int = 0;
 
 	var _drawCalls:Array<Int> = [];
@@ -220,9 +220,9 @@ class Stats extends Window
 		{
 			return;
 		}
-		var time:Int = _currentTime = FlxG.game.ticks;
+		var time:Float = _currentTime = FlxG.game.ticks;
 
-		var elapsed:Int = time - _lastTime;
+		var elapsed:Float = time - _lastTime;
 
 		if (elapsed > UPDATE_DELAY)
 		{
@@ -335,7 +335,7 @@ class Stats extends Window
 	 *
 	 * @param 	Time	How long this update took.
 	 */
-	public function flixelUpdate(Time:Int):Void
+	public function flixelUpdate(Time:Float):Void
 	{
 		if (_paused)
 			return;
@@ -347,7 +347,7 @@ class Stats extends Window
 	 *
 	 * @param	Time	How long this render took.
 	 */
-	public function flixelDraw(Time:Int):Void
+	public function flixelDraw(Time:Float):Void
 	{
 		if (_paused)
 			return;

--- a/flixel/system/debug/watch/Tracker.hx
+++ b/flixel/system/debug/watch/Tracker.hx
@@ -84,7 +84,11 @@ class Tracker extends Watch
 
 			addProfile(new TrackerProfile(FlxG, [
 				"width", "height", "worldBounds.x", "worldBounds.y", "worldBounds.width", "worldBounds.height", "worldDivisions", "updateFramerate",
-				"drawFramerate", "elapsed", "maxElapsed", "autoPause", "fixedTimestep", "timeScale"
+				"drawFramerate",
+				"elapsed",
+				"maxElapsed",
+				"autoPause",
+				"timeScale"
 			]));
 
 			addProfile(new TrackerProfile(FlxBasePoint, ["x", "y"]));

--- a/flixel/text/FlxInputText.hx
+++ b/flixel/text/FlxInputText.hx
@@ -286,7 +286,7 @@ class FlxInputText extends FlxText implements IFlxInputText
 	/**
 	 * Stores the last time that this text field was pressed on, which helps to check for double-presses.
 	 */
-	var _lastPressTime:Int = 0;
+	var _lastPressTime:Float = 0;
 	
 	/**
 	 * Timer for the text field to scroll vertically when dragging over it.


### PR DESCRIPTION
This pr implements the following adjustments in order for the pr on https://github.com/FunkinCrew/openfl/pull/18 to work properly:
 - Makes all the tick variables use `Float`.
 - `FlxG.game.ticks` now uses a `Float` instead of `Int`.
 - `FlxG.fixedTimestep` is now made useless as the mainloop rn is accurate enough.
 - Improves the speed `flixel`'s mainloop runs at by using `__enterFrame` instead of `openfl`'s `ENTER_FRAME` event.