### PR TITLE
Fix `focusLostFrame`

### DIFF
--- a/flixel/FlxGame.hx
+++ b/flixel/FlxGame.hx
@@ -354,6 +354,8 @@ class FlxGame extends Sprite
 		FlxG.signals.focusGained.dispatch();
 		_state.onFocus();
 
+		stage.frameRate = FlxG.drawFramerate;
+
 		if (!FlxG.autoPause)
 			return;
 
@@ -365,8 +367,6 @@ class FlxGame extends Sprite
 		#if FLX_DEBUG
 		debugger.stats.onFocus();
 		#end
-
-		stage.frameRate = FlxG.drawFramerate;
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.onFocus();
 		#end
@@ -384,6 +384,8 @@ class FlxGame extends Sprite
 		FlxG.signals.focusLost.dispatch();
 		_state.onFocusLost();
 
+		stage.frameRate = focusLostFramerate;
+
 		if (!FlxG.autoPause)
 			return;
 
@@ -395,8 +397,6 @@ class FlxGame extends Sprite
 		#if FLX_DEBUG
 		debugger.stats.onFocusLost();
 		#end
-
-		stage.frameRate = focusLostFramerate;
 		#if FLX_SOUND_SYSTEM
 		FlxG.sound.onFocusLost();
 		#end


### PR DESCRIPTION
Fix `FlxGame.focusLostFrame` not applying in false `autoPause`,
Can help with performance of the game if user is not in focus with the game.


https://github.com/user-attachments/assets/469ac6fc-ed82-4d7c-9d89-8f770fe989cd

