### PR TITLE
Round the rect in FlxCamera to properly crop

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1376,8 +1376,8 @@ class FlxCamera extends FlxBasic
 		{
 			rect.x = rect.y = 0;
 
-			rect.width = width * initialZoom * FlxG.scaleMode.scale.x;
-			rect.height = height * initialZoom * FlxG.scaleMode.scale.y;
+			rect.width = Math.floor(width * initialZoom * FlxG.scaleMode.scale.x);
+			rect.height = Math.floor(height * initialZoom * FlxG.scaleMode.scale.y);
 
 			_scrollRect.scrollRect = rect;
 


### PR DESCRIPTION
Before:
<img width="158" height="450" alt="image" src="https://github.com/user-attachments/assets/9b75a2f3-a641-4c7a-ac32-6f9e87500863" />


After:
<img width="125" height="404" alt="image" src="https://github.com/user-attachments/assets/cb248477-61fb-4787-86f0-375565fd20e8" />
