### PR TITLE
Prevent repetitive `onVolumeChange` calls

### DIFF
--- a/flixel/system/frontEnds/SoundFrontEnd.hx
+++ b/flixel/system/frontEnds/SoundFrontEnd.hx
@@ -365,9 +365,7 @@ class SoundFrontEnd
 	public function changeVolume(Amount:Float):Void
 	{
 		muted = false;
-		volume = logToLinear(volume);
-		volume += Amount;
-		volume = linearToLog(volume);
+		volume = linearToLog(logToLinear(volume) + Amount);
 		showSoundTray(Amount > 0);
 	}
 


### PR DESCRIPTION
Change `volume` in one line so that `set_volume` and `onVolumeChange` don't get called three times