### PR TITLE
[FEATURE] Accurate Scrolling

### DIFF
--- a/flixel/input/mouse/FlxMouse.hx
+++ b/flixel/input/mouse/FlxMouse.hx
@@ -45,8 +45,18 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	/**
 	 * Current "delta" value of mouse wheel. If the wheel was just scrolled up,
 	 * it will have a positive value and vice versa. Otherwise the value will be 0.
+	 *
+	 * **You should use `deltaWheel` instead as it exposes the x-axis scrolling direction**
+	 * **To keep compatability `wheel` returns to the old behavior of OpenFL which is the rounded wheel delta, for decimal wheel use `deltaWheel.y`**
 	 */
 	public var wheel(default, null):Int = 0;
+
+	/**
+	 * Accurate current "delta" value of mouse wheel. If the wheel was scrolled in any direction,
+	 * it will have a value on the the respective axis (can be both x and y on some hardware like trackpacds and such).
+	 * Otherwise it is assigned to 0 on the X and Y axis.
+	 */
+	public var deltaWheel(default, null):FlxPoint = FlxPoint.get();
 
 	/**
 	 * A display container for the mouse cursor. It is a child of FlxGame and
@@ -178,6 +188,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 	 */
 	#if FLX_POINTER_INPUT
 	public var flickManager(default, null):FlxFlick = new FlxFlick();
+	public var wheelFlickManager(default, null):FlxFlick = new FlxFlick();
 	#end
 
 	#if FLX_MOUSE_ADVANCED
@@ -444,12 +455,12 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 
 		if (cursorBitmap.width > 32 || cursorBitmap.height > 32)
 			throw "BitmapData files used for native cursors cannot exceed 32x32 pixels due to an OS limitation.";
-		
+
 		if(hotSpot == null)
 			hotSpot = new Point();
 		else if (hotSpot.x < 0 || hotSpot.y < 0 || hotSpot.x > cursorBitmap.width || hotSpot.y > cursorBitmap.height)
 			throw 'Invalid hotSpot: $hotSpot';
-		
+
 		var cursorData = new MouseCursorData();
 		cursorData.hotSpot = hotSpot;
 		cursorData.data = cursorVector;
@@ -518,6 +529,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 
 		#if FLX_POINTER_INPUT
 		flickManager.destroy();
+		wheelFlickManager.destroy();
 		#end
 	}
 
@@ -602,9 +614,21 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		_rightButton.update();
 		#end
 
+		#if FLX_POINTER_INPUT
+		if (!_wheelUsed)
+		{
+			wheelFlickManager.initFlick(deltaWheel);
+		}
+		else
+		{
+			wheelFlickManager.destroy();
+		}
+		#end
+
 		// Update the wheel
 		if (!_wheelUsed)
 		{
+			deltaWheel.set(0, 0);
 			wheel = 0;
 		}
 		_wheelUsed = false;
@@ -625,7 +649,8 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			flickManager.destroy();
 		}
 
-			flickManager.update(FlxG.elapsed);
+		flickManager.update(FlxG.elapsed);
+		wheelFlickManager.update(FlxG.elapsed);
 		#end
 	}
 
@@ -684,6 +709,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		if (enabled)
 		{
 			_wheelUsed = true;
+			deltaWheel.set(flashEvent.deltaX, flashEvent.deltaY);
 			wheel = flashEvent.delta;
 		}
 	}
@@ -929,7 +955,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		if ((_lastX == gameX)
 			&& (_lastY == gameY)
 			&& (_lastLeftButtonState == _leftButton.current)
-			&& (_lastWheel == wheel))
+			&& (_lastWheel == deltaWheel.y))
 		{
 			return null;
 		}
@@ -937,7 +963,7 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 		_lastX = gameX;
 		_lastY = gameY;
 		_lastLeftButtonState = _leftButton.current;
-		_lastWheel = wheel;
+		_lastWheel = deltaWheel.y;
 		return new MouseRecord(_lastX, _lastY, _leftButton.current, _lastWheel);
 	}
 
@@ -953,7 +979,8 @@ class FlxMouse extends FlxPointer implements IFlxInputManager
 			_stage.dispatchEvent(new MouseEvent(MouseEvent.MOUSE_UP, true, false, record.x, record.y));
 		}
 		_lastLeftButtonState = _leftButton.current = record.button;
-		wheel = record.wheel;
+		deltaWheel.y = record.wheel;
+		wheel = Std.int(record.wheel);
 		_rawX = record.x;
 		_rawY = record.y;
 		updatePositions();


### PR DESCRIPTION
## All Pull Requests Needed

- https://github.com/FunkinCrew/flixel/pull/20
- https://github.com/FunkinCrew/lime/pull/82
- https://github.com/FunkinCrew/openfl/pull/35

## What does this specific PR do?
The Flixel PR adds support for the flick manager on the wheel and also exposes the X axis from the `deltaWheel` point in FlxMouse as well as making the `deltaWheel` point uses the actual non-rounded coordinates from SDL which comes through Lime and OpenFL
(Note: keeps the `wheel` property rounded for backwards compatilibty)

## Description
This series of PRs adds support for decimal wheel support in Flixel (and adds flicking so scrolling fast makes a velocity for the wheel flick manager) so its not rounded from the OpenFL side and direction is fixed from the Lime (NDLL) Side