### PR TITLE
[BUGFIX] Tweak scrollRect-cutting values to fix black lines

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1377,8 +1377,8 @@ class FlxCamera extends FlxBasic
 		{
 			rect.x = rect.y = 0;
 
-			rect.width = Math.round(width * initialZoom * FlxG.scaleMode.scale.x) + (isTransparent ? 0 : -2);
-			rect.height = Math.round(height * initialZoom * FlxG.scaleMode.scale.y) + (isTransparent ? 0 : -2);
+			rect.width = Math.round(width * initialZoom * FlxG.scaleMode.scale.x) + (isTransparent ? 0 : -1);
+			rect.height = Math.round(height * initialZoom * FlxG.scaleMode.scale.y) + (isTransparent ? 0 : -1);
 
 			_scrollRect.scrollRect = rect;
 


### PR DESCRIPTION
Replaces the -2 with -1 in `updateScrollRect` cause I didn't see how atrocious the black lines were until Hundrec pointed it out :eric_whoopsie: