### PR TITLE
Fix camera not resizing when inactive

### DIFF
--- a/flixel/FlxCamera.hx
+++ b/flixel/FlxCamera.hx
@@ -1840,6 +1840,7 @@ class FlxCamera extends FlxBasic
 
 		updateScrollRect();
 		updateInternalSpritePositions();
+		updateFlashSpritePosition();
 
 		FlxG.cameras.cameraResized.dispatch(this);
 	}


### PR DESCRIPTION
This PR fixes an issue where cameras that have `active` disabled don't properly correct their size when resizing the window.

Edit: This should fix the bug where the chart editor doesn't resize properly when playtesting.