### PR TITLE
 replace implicit 'to' cast with @:to function for Haxe 4.3 compatibility

### DIFF
--- a/flixel/graphics/frames/FlxFrame.hx
+++ b/flixel/graphics/frames/FlxFrame.hx
@@ -761,8 +761,13 @@ enum abstract FlxFrameAngle(Int) from Int to Int
  * `bottom`. This is for optimization reasons, to reduce arithmetic when drawing vertices
  */
 @:forward(put)
-abstract FlxUVRect(FlxRect) from FlxRect to flixel.util.FlxPool.IFlxPooled
+abstract FlxUVRect(FlxRect) from FlxRect
 {
+	@:to public inline function toIFlxPooled():flixel.util.FlxPool.IFlxPooled
+	{
+		return this;
+	}
+
 	public var left(get, set):Float;
 	inline function get_left():Float { return this.x; }
 	inline function set_left(value):Float { return this.x = value; }


### PR DESCRIPTION
haxe 4.3 introduced stricter validation for abstract `from/to` declarations, requiring us to do this change, the implicit `to flixel.util.FlxPool.IFlxPooled` on FlxUVRect fails this check since FlxRect's underlying type isn't directly IFlxPooled.

```bash
 ERROR  C:/Users/Homura/GitHub/FNF-Shadow-Engine/.haxelib/flixel/git/flixel/graphics/frames/FlxFrame.hx:764: characters 45-75

 764 | abstract FlxUVRect(FlxRect) from FlxRect to flixel.util.FlxPool.IFlxPooled
     |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     | You can only declare from/to with compatible types
```